### PR TITLE
added parametr pFileContent, wich may contain already readed css file

### DIFF
--- a/lib/css-b64-images.js
+++ b/lib/css-b64-images.js
@@ -7,8 +7,12 @@ var fs = require('fs'),
 
 module.exports = optimizeFile;
 
-function optimizeFile(cssFile, root, cb) {
-  fs.readFile(cssFile, function(err, css){
+/* added parametr pFileContent, wich contains
+ * already readed css file if it is.
+ * in other case - file readed
+ */
+function optimizeFile(cssFile, root, cb, pfileContent) {
+  var fileReaded=(function(err, css){
     if(err) return cb(err, css);
     css = css.toString();
     var urls = [], match;
@@ -38,7 +42,12 @@ function optimizeFile(cssFile, root, cb) {
       });
     }
   });
-}
+  
+    /* if file content already readed pass it */
+    if(pfileContent)fileReaded(false, pfileContent)
+    /* if not - reading it */
+    else fs.readFile(cssFile, fileReaded);
+}  
 
 function replaceUrlByB64(imageUrl, imagePath, css, cb){
   imagePath = imagePath.replace(/[?#].*/g, '');


### PR DESCRIPTION
First of all you write a good and useful library css-base64-images, if you don't mind i'll use it in my no-commercial js-application.
To the case. When i'm looking for a params to optimizeFile, I saw that there'is not provided variant, that css-file is already readed (i need this in my project), so I add this condition. Would be great if you add this (or similarly) thing in your library. Thanks for great work and attention :).
