### PR TITLE
Little bug with rootPath variable

### DIFF
--- a/lib/css-b64-images.js
+++ b/lib/css-b64-images.js
@@ -28,7 +28,7 @@ function fromString(css, relativePath, rootPath , cb) {
 
     var imagePath;
     if(absoluteUrlRegex.test(imageUrl)) {
-      imagePath = Path.join(root, imageUrl.substr(1));
+      imagePath = Path.join(rootPath, imageUrl.substr(1));
     }else{
       imagePath = Path.join(relativePath, imageUrl);
     }


### PR DESCRIPTION
Thank you for adding new function fromString, it's more convenient now :). You must be made a typo with variable root. Now everything works good.
