### PR TITLE
Use mediatype in dataurl instead of filename extension

### DIFF
--- a/lib/css-b64-images.js
+++ b/lib/css-b64-images.js
@@ -3,7 +3,20 @@ var fs = require('fs'),
   /* Adapted from https://gist.github.com/2594980 */
   imgRegex = /url\s?\(['"]?(.*?)(?=['"]?\))/gi,
   absoluteUrlRegex = /^\//,
-  externalUrlRegex = /http/;
+  externalUrlRegex = /http/,
+  mediatypes = {
+    'eot'       : 'application/vnd.ms-fontobject',
+    'gif'       : 'image/gif',
+    'ico'       : 'image/vnd.microsoft.icon',
+    'jpg'       : 'image/jpeg',
+    'jpeg'      : 'image/jpeg',
+    'otf'       : 'application/x-font-opentype',
+    'png'       : 'image/png',
+    'svg'       : 'image/svg+xml',
+    'ttf'       : 'application/x-font-ttf',
+    'webp'      : 'image/webp',
+    'woff'      : 'application/x-font-woff'
+  };
 
 module.exports = {
   fromFile: fromFile,
@@ -57,7 +70,7 @@ function replaceUrlByB64(imageUrl, imagePath, css, cb){
     fs.readFile(imagePath, 'base64', function(err, img){
       if(err) return cb(err, css);
       var ext = imagePath.substr(imagePath.lastIndexOf('.') + 1);
-      var newCss = css.replace(imageUrl, 'data:image/' + ext + ';base64,' + img);
+      var newCss = css.replace(imageUrl, 'data:' + mediatypes[ext] + ';base64,' + img);
       cb(null, newCss);
     });
   });

--- a/test/css-b64-images-test.js
+++ b/test/css-b64-images-test.js
@@ -33,4 +33,6 @@ function cssShouldBeCorrect(css){
   css.should.include(".external {\n  background: url('http");
   css.should.include(".tooBig {\n  background: url('../img");
   css.should.include(".not-found {\n  background: url('../img");
+
+  css.should.include(".mediatype {\n  background: url('data:image/svg+xml;base64,");
 }

--- a/test/fixture/css/style.css
+++ b/test/fixture/css/style.css
@@ -46,3 +46,7 @@
 .not-found {
   background: url('../img/nlabal.png');
 }
+
+.mediatype {
+  background: url('../img/dots.svg');
+}

--- a/test/fixture/img/dots.svg
+++ b/test/fixture/img/dots.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 32 32" height="100%" width="100%" version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve">
+<rect id="rect4" width="32" fill="#8f5902" height="32"/>
+<circle id="circle6" cy="8" cx="8" r="8" fill="#e9b96e"/>
+<circle id="circle8" cy="24" cx="24" r="8" fill="#c17d11"/>
+</svg>


### PR DESCRIPTION
According to the specification of the [the "data" URL scheme](http://tools.ietf.org/html/rfc2397), the dataurl should use a mediatype. 

This pull request changes the behavior in this module to append a mediatype in the dataurl instead of a filenames extension. Using just the filename extension in the dataurl causes some problems for some files. 

The best example is that svg as backgrounds will not work in most browsers if the mediatype is wrong.

By using just the filename extension of a svg file we will get the following, and failing, dataurl:
data:image/svg;base64

The correct, and working, dataurl is:
data:image/svg+xml;base64
