### PR TITLE
Skip for already encoded images

### DIFF
--- a/lib/css-b64-images.js
+++ b/lib/css-b64-images.js
@@ -7,6 +7,7 @@ var fs = require('fs'),
   imgRegex = /url\s?\(['"]?(.*?)(?=['"]?\))/gi,
   absoluteUrlRegex = /^\//,
   externalUrlRegex = /http/,
+  alreadyEncodedRegex = /data/,
   mediatypes = {
     '.eot'       : 'application/vnd.ms-fontobject',
     '.gif'       : 'image/gif',
@@ -47,6 +48,9 @@ function fromString(css, relativePath, rootPath , options, cb) {
   function base64img(imageUrl, cb){
     if(externalUrlRegex.test(imageUrl)) {
       return cb(new Error('Skip ' + imageUrl + ' External file.'), css);
+    }
+    if(alreadyEncodedRegex.test(imageUrl)) {
+      return cb(new Error('Skip ' + imageUrl + ' Already encoded.'), css);
     }
 
     var imagePath;


### PR DESCRIPTION
Hi,

I added a new regex for matching already encoded images and skipping them. This was the case for me when using the latest jquery-ui.css file. It alreay had a couple of the images encoded.

- Florin