### PR TITLE
remove hash filter

### DIFF
--- a/lib/css-b64-images.js
+++ b/lib/css-b64-images.js
@@ -79,7 +79,6 @@ function fromFile(cssFile, root, options, cb) {
 }
 
 function replaceUrlByB64(imageUrl, imagePath, css, options, cb){
-  imagePath = imagePath.replace(/[?#].*/g, '');
   fs.stat(imagePath, function(err, stat){
     if(err) return cb(err, css);
     if (stat.size > options.maxSize){


### PR DESCRIPTION
Stops this error from being thrown when inlining images with # signs in their file names:

```
{ [Error: EISDIR: illegal operation on a directory, read] errno: -21, code: 'EISDIR', syscall: 'read' }
```
